### PR TITLE
Fix deadlock

### DIFF
--- a/semgroup_test.go
+++ b/semgroup_test.go
@@ -70,3 +70,17 @@ func TestGroup_multiple_tasks_errors(t *testing.T) {
 		t.Errorf("error should be:\n%s\ngot:\n%s\n", wantErr, err.Error())
 	}
 }
+
+func TestGroup_deadlock(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := NewGroup(canceledCtx, 1)
+
+	g.Go(func() error { return nil })
+	g.Go(func() error { return nil })
+
+	err := g.Wait()
+	if err != nil {
+		t.Fatalf("g.Wait() should not return an error")
+	}
+}

--- a/semgroup_test.go
+++ b/semgroup_test.go
@@ -80,7 +80,14 @@ func TestGroup_deadlock(t *testing.T) {
 	g.Go(func() error { return nil })
 
 	err := g.Wait()
-	if err != nil {
-		t.Fatalf("g.Wait() should not return an error")
+	if err == nil {
+		t.Fatalf("g.Wait() should return an error")
+	}
+
+	wantErr := `1 error(s) occured:
+* couldn't acquire semaphore: context canceled`
+
+	if wantErr != err.Error() {
+		t.Errorf("error should be:\n%s\ngot:\n%s\n", wantErr, err.Error())
 	}
 }


### PR DESCRIPTION
A deadlock can occur if `Acquire` fails as `wg.Done` will not be called in the goroutine but we called `wg.Add` before `Acquier`. [Link](https://github.com/fatih/semgroup/blob/55984f5e8d74254145d0bca5da50bc8e596f148d/semgroup.go#L48-L57) to related lines.

This can be eliminated by either moving `wg.Add` just before creating goroutine or by calling `wg.Done` also before returning error. I am not sure which one is better?

Another question: Should we append `error` returned from `g.Go` to `multiError`?

By the way sorry for questions in PR but i thought it would be better to send test code with the questions so asking from PR instead of an issue.