### PR TITLE
Implements error methods

### DIFF
--- a/semgroup.go
+++ b/semgroup.go
@@ -108,3 +108,12 @@ func (e multiError) Is(target error) bool {
 	}
 	return false
 }
+
+func (e multiError) As(target interface{}) bool {
+	for _, err := range e {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/semgroup.go
+++ b/semgroup.go
@@ -10,6 +10,7 @@ package semgroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -97,4 +98,13 @@ func (e multiError) ErrorOrNil() error {
 	}
 
 	return e
+}
+
+func (e multiError) Is(target error) bool {
+	for _, err := range e {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Implements `Is(target error)` and `As(target interface{})` so that `errors.Is` and `errors.As` can examine errors by passing err which is returned from `semgroup.Wait()`.