### PR TITLE
chore: bump x/sync to 0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/fatih/semgroup
 
 go 1.17
 
-require golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+require golang.org/x/sync v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/semgroup_test.go
+++ b/semgroup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -85,11 +86,10 @@ func TestGroup_deadlock(t *testing.T) {
 		t.Fatalf("g.Wait() should return an error")
 	}
 
-	wantErr := `1 error(s) occurred:
-* couldn't acquire semaphore: context canceled`
+	wantErr := `couldn't acquire semaphore: context canceled`
 
-	if wantErr != err.Error() {
-		t.Errorf("error should be:\n%s\ngot:\n%s\n", wantErr, err.Error())
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("error should contain:\n%s\ngot:\n%s\n", wantErr, err.Error())
 	}
 }
 


### PR DESCRIPTION
Note that this version changes the behavior of semaphore slightly. After https://cs.opensource.google/go/x/sync/+/14be23e5b48bec28285f8a694875175ecacfddb3 the semaphore package will reliably raise errors for both go routines

change the test to test for a substring to be more relaxed in case that behavior gets reverted